### PR TITLE
Spark UI:  Fallback to private IP if public DNS not available

### DIFF
--- a/templates/root/spark/conf/spark-env.sh
+++ b/templates/root/spark/conf/spark-env.sh
@@ -14,8 +14,12 @@ export MASTER=`cat /root/spark-ec2/cluster-url`
 export SPARK_SUBMIT_LIBRARY_PATH="$SPARK_SUBMIT_LIBRARY_PATH:/root/ephemeral-hdfs/lib/native/"
 export SPARK_SUBMIT_CLASSPATH="$SPARK_CLASSPATH:$SPARK_SUBMIT_CLASSPATH:/root/ephemeral-hdfs/conf"
 
-# Bind Spark's web UIs to this machine's public EC2 hostname:
-export SPARK_PUBLIC_DNS=`wget -q -O - http://169.254.169.254/latest/meta-data/public-hostname`
+# Bind Spark's web UIs to this machine's public EC2 hostname otherwise fallback to private IP:
+SPARK_PUBLIC_DNS=`wget -q -O - http://169.254.169.254/latest/meta-data/public-hostname`
+if [[ -z "$SPARK_PUBLIC_DNS" ]]; then
+  SPARK_PUBLIC_DNS=$SPARK_MASTER_IP
+fi
+export SPARK_PUBLIC_DNS
 
 # Set a high ulimit for large shuffles
 ulimit -n 1000000


### PR DESCRIPTION
I am using the spark-ec2 script to launch a cluster in an EC2 VPC which does not have a public DNS available.  With the current configuration, the links in the Spark UI are not properly configured.  This change will allow for the use of the master's private IP address if a public hostname can not resolve.
